### PR TITLE
fix(iOS): encode uri for compatibility with 16.4

### DIFF
--- a/ios/Video/Features/RCTVideoUtils.swift
+++ b/ios/Video/Features/RCTVideoUtils.swift
@@ -39,15 +39,19 @@ enum RCTVideoUtils {
      *
      * \returns The playable duration of the current player item in seconds.
      */
-    static func calculatePlayableDuration(_ player: AVPlayer?, withSource source: VideoSource?) -> NSNumber {
+    static func calculatePlayableDuration(_ player: AVPlayer?, withSource source: VideoSource?)
+        -> NSNumber
+    {
         guard let player,
-              let video: AVPlayerItem = player.currentItem,
-              video.status == AVPlayerItem.Status.readyToPlay else {
+            let video: AVPlayerItem = player.currentItem,
+            video.status == AVPlayerItem.Status.readyToPlay
+        else {
             return 0
         }
 
         if source?.cropStart != nil && source?.cropEnd != nil {
-            return NSNumber(value: (Float64(source?.cropEnd ?? 0) - Float64(source?.cropStart ?? 0)) / 1000)
+            return NSNumber(
+                value: (Float64(source?.cropEnd ?? 0) - Float64(source?.cropStart ?? 0)) / 1000)
         }
 
         var effectiveTimeRange: CMTimeRange?
@@ -63,7 +67,8 @@ enum RCTVideoUtils {
             let playableDuration: Float64 = CMTimeGetSeconds(CMTimeRangeGetEnd(effectiveTimeRange))
             if playableDuration > 0 {
                 if source?.cropStart != nil {
-                    return NSNumber(value: playableDuration - Float64(source?.cropStart ?? 0) / 1000)
+                    return NSNumber(
+                        value: playableDuration - Float64(source?.cropStart ?? 0) / 1000)
                 }
 
                 return playableDuration as NSNumber
@@ -73,16 +78,20 @@ enum RCTVideoUtils {
         return 0
     }
 
-    static func urlFilePath(filepath: NSString!, searchPath: FileManager.SearchPathDirectory) -> NSURL! {
+    static func urlFilePath(filepath: NSString!, searchPath: FileManager.SearchPathDirectory)
+        -> NSURL!
+    {
         if filepath.contains("file://") {
             return NSURL(string: filepath as String)
         }
 
         // if no file found, check if the file exists in the Document directory
-        let paths: [String]! = NSSearchPathForDirectoriesInDomains(searchPath, .userDomainMask, true)
+        let paths: [String]! = NSSearchPathForDirectoriesInDomains(
+            searchPath, .userDomainMask, true)
         var relativeFilePath: String! = filepath.lastPathComponent
         // the file may be multiple levels below the documents directory
-        let directoryString: String! = searchPath == .cachesDirectory ? "Library/Caches/" : "Documents"
+        let directoryString: String! =
+            searchPath == .cachesDirectory ? "Library/Caches/" : "Documents"
         let fileComponents: [String]! = filepath.components(separatedBy: directoryString)
         if fileComponents.count > 1 {
             relativeFilePath = fileComponents[1]
@@ -97,8 +106,9 @@ enum RCTVideoUtils {
 
     static func playerItemSeekableTimeRange(_ player: AVPlayer?) -> CMTimeRange {
         if let playerItem = player?.currentItem,
-           playerItem.status == .readyToPlay,
-           let firstItem = playerItem.seekableTimeRanges.first {
+            playerItem.status == .readyToPlay,
+            let firstItem = playerItem.seekableTimeRanges.first
+        {
             return firstItem.timeRangeValue
         }
 
@@ -107,7 +117,8 @@ enum RCTVideoUtils {
 
     static func playerItemDuration(_ player: AVPlayer?) -> CMTime {
         if let playerItem = player?.currentItem,
-           playerItem.status == .readyToPlay {
+            playerItem.status == .readyToPlay
+        {
             return playerItem.duration
         }
 
@@ -131,7 +142,7 @@ enum RCTVideoUtils {
 
         let group = await RCTVideoAssetsUtils.getMediaSelectionGroup(asset: asset, for: .audible)
 
-        for i in 0 ..< (group?.options.count ?? 0) {
+        for i in 0..<(group?.options.count ?? 0) {
             let currentOption = group?.options[i]
             var title = ""
             let values = currentOption?.commonMetadata.map(\.value)
@@ -140,14 +151,16 @@ enum RCTVideoUtils {
             }
             let language: String! = currentOption?.extendedLanguageTag ?? ""
 
-            let selectedOption: AVMediaSelectionOption? = player.currentItem?.currentMediaSelection.selectedMediaOption(in: group!)
+            let selectedOption: AVMediaSelectionOption? = player.currentItem?.currentMediaSelection
+                .selectedMediaOption(in: group!)
 
-            let audioTrack = [
-                "index": NSNumber(value: i),
-                "title": title,
-                "language": language ?? "",
-                "selected": currentOption?.displayName == selectedOption?.displayName,
-            ] as [String: Any]
+            let audioTrack =
+                [
+                    "index": NSNumber(value: i),
+                    "title": title,
+                    "language": language ?? "",
+                    "selected": currentOption?.displayName == selectedOption?.displayName,
+                ] as [String: Any]
             audioTracks.add(audioTrack)
         }
 
@@ -163,7 +176,7 @@ enum RCTVideoUtils {
         var textTracks: [TextTrack] = []
         let group = await RCTVideoAssetsUtils.getMediaSelectionGroup(asset: asset, for: .legible)
 
-        for i in 0 ..< (group?.options.count ?? 0) {
+        for i in 0..<(group?.options.count ?? 0) {
             let currentOption = group?.options[i]
             var title = ""
             let values = currentOption?.commonMetadata.map(\.value)
@@ -172,7 +185,8 @@ enum RCTVideoUtils {
             }
             let language: String! = currentOption?.extendedLanguageTag ?? ""
             let selectedOpt = player.currentItem?.currentMediaSelection
-            let selectedOption: AVMediaSelectionOption? = player.currentItem?.currentMediaSelection.selectedMediaOption(in: group!)
+            let selectedOption: AVMediaSelectionOption? = player.currentItem?.currentMediaSelection
+                .selectedMediaOption(in: group!)
             let textTrack = TextTrack([
                 "index": NSNumber(value: i),
                 "title": title,
@@ -206,7 +220,8 @@ enum RCTVideoUtils {
 
     static func extractDataFromCustomSchemeUrl(from url: URL, scheme: String) -> Data? {
         guard url.scheme == scheme,
-              let adoptURL = RCTVideoUtils.replaceURLScheme(url: url, scheme: nil) else { return nil }
+            let adoptURL = RCTVideoUtils.replaceURLScheme(url: url, scheme: nil)
+        else { return nil }
 
         return Data(base64Encoded: adoptURL.absoluteString)
     }
@@ -243,8 +258,10 @@ enum RCTVideoUtils {
         return mixComposition
     }
 
-    static func getValidTextTracks(asset: AVAsset, assetOptions: NSDictionary?, mixComposition: AVMutableComposition,
-                                   textTracks: [TextTrack]?) async -> [TextTrack] {
+    static func getValidTextTracks(
+        asset: AVAsset, assetOptions: NSDictionary?, mixComposition: AVMutableComposition,
+        textTracks: [TextTrack]?
+    ) async -> [TextTrack] {
         var validTextTracks: [TextTrack] = []
         var tracks: [([AVAssetTrack], AVURLAsset)] = []
 
@@ -257,34 +274,44 @@ enum RCTVideoUtils {
                 let textUri: String = textTrack.uri
 
                 if textUri.lowercased().hasPrefix("http") {
-                    textURLAsset = AVURLAsset(url: NSURL(string: textUri)! as URL, options: (assetOptions as! [String: Any]))
+                    textURLAsset = AVURLAsset(
+                        url: NSURL(string: textUri)! as URL,
+                        options: (assetOptions as! [String: Any]))
                 } else {
                     let isDisabledTrack: Bool! = textTrack.type == "disabled"
-                    let searchPath: FileManager.SearchPathDirectory = isDisabledTrack ? .cachesDirectory : .documentDirectory
+                    let searchPath: FileManager.SearchPathDirectory =
+                        isDisabledTrack ? .cachesDirectory : .documentDirectory
                     textURLAsset = AVURLAsset(
-                        url: RCTVideoUtils.urlFilePath(filepath: textUri as NSString?, searchPath: searchPath) as URL,
+                        url: RCTVideoUtils.urlFilePath(
+                            filepath: textUri as NSString?, searchPath: searchPath) as URL,
                         options: nil
                     )
                 }
 
-                if let track = await RCTVideoAssetsUtils.getTracks(asset: textURLAsset, withMediaType: .text) {
+                if let track = await RCTVideoAssetsUtils.getTracks(
+                    asset: textURLAsset, withMediaType: .text)
+                {
                     tracks.append((track, textURLAsset))
                 }
             }
 
             for (index, tracksPair) in tracks.enumerated() {
                 let (tracks, trackAsset) = tracksPair
-                guard let track = tracks.first else { continue } // fix when there's no textTrackAsset
+                guard let track = tracks.first else { continue }  // fix when there's no textTrackAsset
 
-                let textCompTrack: AVMutableCompositionTrack! = mixComposition.addMutableTrack(withMediaType: AVMediaType.text,
-                                                                                               preferredTrackID: kCMPersistentTrackID_Invalid)
+                let textCompTrack: AVMutableCompositionTrack! = mixComposition.addMutableTrack(
+                    withMediaType: AVMediaType.text,
+                    preferredTrackID: kCMPersistentTrackID_Invalid)
 
                 do {
-                    try textCompTrack.insertTimeRange(CMTimeRangeMake(start: .zero, duration: trackAsset.duration), of: track, at: .zero)
+                    try textCompTrack.insertTimeRange(
+                        CMTimeRangeMake(start: .zero, duration: trackAsset.duration), of: track,
+                        at: .zero)
                     validTextTracks.append(textTracks[index])
                 } catch {
                     // TODO: upgrade error by call some props callback to better inform user
-                    print("Error occurred on textTrack insert attempt: \(error.localizedDescription)")
+                    print(
+                        "Error occurred on textTrack insert attempt: \(error.localizedDescription)")
                     continue
                 }
             }
@@ -315,7 +342,9 @@ enum RCTVideoUtils {
             let stringToWrite = "WEBVTT\n\n1\n99:59:59.000 --> 99:59:59.001\n."
 
             do {
-                try stringToWrite.write(to: URL(fileURLWithPath: filePath), atomically: true, encoding: String.Encoding.utf8)
+                try stringToWrite.write(
+                    to: URL(fileURLWithPath: filePath), atomically: true,
+                    encoding: String.Encoding.utf8)
             } catch {
                 return nil
             }
@@ -339,7 +368,10 @@ enum RCTVideoUtils {
 
     static func preparePHAsset(uri: String) async -> AVAsset? {
         let assetId = String(uri[uri.index(uri.startIndex, offsetBy: "ph://".count)...])
-        guard let phAsset = PHAsset.fetchAssets(withLocalIdentifiers: [assetId], options: nil).firstObject else {
+        guard
+            let phAsset = PHAsset.fetchAssets(withLocalIdentifiers: [assetId], options: nil)
+                .firstObject
+        else {
             return nil
         }
 
@@ -347,24 +379,29 @@ enum RCTVideoUtils {
         options.isNetworkAccessAllowed = true
 
         return await withCheckedContinuation { continuation in
-            PHCachingImageManager().requestAVAsset(forVideo: phAsset, options: options) { data, _, _ in
+            PHCachingImageManager().requestAVAsset(forVideo: phAsset, options: options) {
+                data, _, _ in
                 continuation.resume(returning: data)
             }
         }
     }
 
-    static func prepareAsset(source: VideoSource) -> (asset: AVURLAsset?, assetOptions: NSMutableDictionary?)? {
-        guard let sourceUri = source.uri, sourceUri != "" else { return nil }
+    static func prepareAsset(source: VideoSource) -> (
+        asset: AVURLAsset?, assetOptions: NSMutableDictionary?
+    )? {
         var asset: AVURLAsset!
         let bundlePath = Bundle.main.path(forResource: source.uri, ofType: source.type) ?? ""
-        let url = source.isNetwork || source.isAsset
-            ? URL(string: source.uri ?? "")
+        let encodedUri = source.uri?.addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed)
+        let url =
+            (source.isNetwork || source.isAsset)
+            ? URL(string: encodedUri ?? "")
             : URL(fileURLWithPath: bundlePath)
         let assetOptions: NSMutableDictionary! = NSMutableDictionary()
 
         if source.isNetwork {
             if let headers = source.requestHeaders, !headers.isEmpty {
-                assetOptions.setObject(headers, forKey: "AVURLAssetHTTPHeaderFieldsKey" as NSCopying)
+                assetOptions.setObject(
+                    headers, forKey: "AVURLAssetHTTPHeaderFieldsKey" as NSCopying)
             }
             let cookies: [AnyObject]! = HTTPCookieStorage.shared.cookies
             assetOptions.setObject(cookies, forKey: AVURLAssetHTTPCookiesKey as NSCopying)
@@ -379,8 +416,10 @@ enum RCTVideoUtils {
         return mapping.compactMap { createMetadataItem(for: $0, value: $1) }
     }
 
-    static func createMetadataItem(for identifier: AVMetadataIdentifier,
-                                   value: Any) -> AVMetadataItem {
+    static func createMetadataItem(
+        for identifier: AVMetadataIdentifier,
+        value: Any
+    ) -> AVMetadataItem {
         let item = AVMutableMetadataItem()
         item.identifier = identifier
         item.value = value as? NSCopying & NSObjectProtocol
@@ -418,7 +457,9 @@ enum RCTVideoUtils {
         }
     }
 
-    static func generateVideoComposition(asset: AVAsset, filter: CIFilter) async -> AVVideoComposition? {
+    static func generateVideoComposition(asset: AVAsset, filter: CIFilter) async
+        -> AVVideoComposition?
+    {
         if #available(iOS 16, tvOS 16, visionOS 1.0, *) {
             return try? await AVVideoComposition.videoComposition(
                 with: asset,
@@ -428,7 +469,8 @@ enum RCTVideoUtils {
                     } else {
                         let image: CIImage! = request.sourceImage.clampedToExtent()
                         filter.setValue(image, forKey: kCIInputImageKey)
-                        let output: CIImage! = filter.outputImage?.cropped(to: request.sourceImage.extent)
+                        let output: CIImage! = filter.outputImage?.cropped(
+                            to: request.sourceImage.extent)
                         request.finish(with: output, context: nil)
                     }
                 }
@@ -437,13 +479,15 @@ enum RCTVideoUtils {
             #if !os(visionOS)
                 return AVVideoComposition(
                     asset: asset,
-                    applyingCIFiltersWithHandler: { (request: AVAsynchronousCIImageFilteringRequest) in
+                    applyingCIFiltersWithHandler: {
+                        (request: AVAsynchronousCIImageFilteringRequest) in
                         if filter == nil {
                             request.finish(with: request.sourceImage, context: nil)
                         } else {
                             let image: CIImage! = request.sourceImage.clampedToExtent()
                             filter.setValue(image, forKey: kCIInputImageKey)
-                            let output: CIImage! = filter.outputImage?.cropped(to: request.sourceImage.extent)
+                            let output: CIImage! = filter.outputImage?.cropped(
+                                to: request.sourceImage.extent)
                             request.finish(with: output, context: nil)
                         }
                     }


### PR DESCRIPTION
<!--
Thanks for opening a PR!
Since this is a volunteer project and is very active, anything you can do to reduce the amount of time needed to review and merge your PR is appreciated.
The following steps will help get your PR merged quickly:

- Update the documentation
If you've added new functionality, update the README.md with an entry for your prop or event.
The entry should be inserted in alphabetical order.

- Provide an example of how to test the change
If the PR requires special testing setup provide all the relevant instructions and files. This may include a sample video file or URL, configuration, or setup steps.

- Focus the PR on only one area
If you're touching multiple different areas that aren't related, break the changes up into multiple PRs.

- Describe the changes
Add a note describing what your PR does. If there is a change to the behavior of the code, explain why it needs to be updated.
-->
## Summary

Soporte para URLs con espacios en versiones de iOS 16

### Motivation

Debido a que habían reportado un issue con iphone 8

### Changes

Para soportar las URLs con espacios en versiones de 16.4 en iOS he añadido el siguiente cambio en la función `prepareAsset`

```swift
        let encodedUri = source.uri?.addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed)
        let url =
                    (source.isNetwork || source.isAsset)
                    ? URL(string: encodedUri ?? "")
                    : URL(fileURLWithPath: bundlePath)

```

