### PR TITLE
fix(dvrProgressManager): evitar throw en setPlaybackType cuando el es…

### DIFF
--- a/src/player/core/progress/dvrProgressManager.ts
+++ b/src/player/core/progress/dvrProgressManager.ts
@@ -327,15 +327,21 @@ export class DVRProgressManagerClass extends BaseProgressManager {
 	}
 
 	async setPlaybackType(playbackType: DVR_PLAYBACK_TYPE, program: any = null): Promise<void> {
-		if (!this._isValidState()) {
-			this._currentLogger?.error("setPlaybackType: Invalid state");
-			throw new Error("setPlaybackType: Invalid state");
-		}
-
 		const previousType = this._playbackType;
 		this._currentLogger?.info(`setPlaybackType: ${previousType} -> ${playbackType}`);
 
+		// Siempre asignar el tipo - es configuración, no requiere estado válido
 		this._playbackType = playbackType;
+
+		// Si el estado no es válido, solo guardar el tipo y programa.
+		// Los side effects (seek, EPG, callbacks) se ejecutarán cuando lleguen datos válidos.
+		if (!this._isValidState()) {
+			this._currentLogger?.debug(
+				"setPlaybackType: State not ready yet, type saved for when data arrives"
+			);
+			this._currentProgram = program;
+			return;
+		}
 
 		// Obtener programa si es necesario
 		if (


### PR DESCRIPTION
…tado no es válido

setPlaybackType es una acción de configuración que no requiere estado válido del reproductor. Ahora asigna el tipo y programa inmediatamente, y difiere los side effects (seek, EPG, callbacks) hasta que lleguen datos válidos.

Corrige error constante en Sentry: "setPlaybackType: Invalid state" causado por reset() que invalida el estado antes de llamar a setPlaybackType.

<!--
Thanks for opening a PR!
Since this is a volunteer project and is very active, anything you can do to reduce the amount of time needed to review and merge your PR is appreciated.
The following steps will help get your PR merged quickly:

- Update the documentation
If you've added new functionality, update the README.md with an entry for your prop or event.
The entry should be inserted in alphabetical order.

- Provide an example of how to test the change
If the PR requires special testing setup provide all the relevant instructions and files. This may include a sample video file or URL, configuration, or setup steps.

- Focus the PR on only one area
If you're touching multiple different areas that aren't related, break the changes up into multiple PRs.

- Describe the changes
Add a note describing what your PR does. If there is a change to the behavior of the code, explain why it needs to be updated.
-->
## Summary

### Motivation

### Changes

## Test plan