### PR TITLE
fix(offline): corregir crashes en reproducción de contenido offline

### DIFF
--- a/src/player/flavours/normal/index.tsx
+++ b/src/player/flavours/normal/index.tsx
@@ -233,6 +233,16 @@ export function NormalFlavour(props: NormalFlavourProps): React.ReactElement {
 		} else {
 			// LÓGICA DEL TUDUM SOLO PARA VOD
 
+			// Guard: si el contenido ya está cargado, significa que props.manifests cambió
+			// de referencia (nuevo array, mismo contenido) por un re-render del padre
+			// (ej: tras resolver watching-progress API). No resetear ni recargar.
+			if (isContentLoadedRef.current) {
+				currentLogger.current?.debug(
+					"useEffect manifests - Content already loaded, skipping reset (manifests reference changed but content is the same)"
+				);
+				return;
+			}
+
 			// Reset completo solo para VOD
 			currentSourceType.current = null;
 			pendingContentSource.current = null;


### PR DESCRIPTION
- Limpiar callbacks pendientes (mainHandler) antes de reinicializar el player para evitar ejecuciones solapadas
- Eliminar guard drmUUID != null en detección de descargas offline, que impedía detectar contenido descargado sin DRM
- Manejar buildMediaSource null con error explícito en lugar de NPE
- Mejorar logs en buildLocalDataSourceFactory para diagnóstico
- Evitar reset de fuente en NormalFlavour cuando manifests cambia de referencia por re-render del padre (ej: watching-progress API)

Refs: CCMA-2306

<!--
Thanks for opening a PR!
Since this is a volunteer project and is very active, anything you can do to reduce the amount of time needed to review and merge your PR is appreciated.
The following steps will help get your PR merged quickly:

- Update the documentation
If you've added new functionality, update the README.md with an entry for your prop or event.
The entry should be inserted in alphabetical order.

- Provide an example of how to test the change
If the PR requires special testing setup provide all the relevant instructions and files. This may include a sample video file or URL, configuration, or setup steps.

- Focus the PR on only one area
If you're touching multiple different areas that aren't related, break the changes up into multiple PRs.

- Describe the changes
Add a note describing what your PR does. If there is a change to the behavior of the code, explain why it needs to be updated.
-->
## Summary

### Motivation

### Changes

## Test plan