### PR TITLE
fix(player): corrige pantalla negra al volver de background durante a…

### DIFF
--- a/android/src/main/java/com/brentvatne/exoplayer/VideoPlaybackService.kt
+++ b/android/src/main/java/com/brentvatne/exoplayer/VideoPlaybackService.kt
@@ -170,10 +170,12 @@ class VideoPlaybackService : MediaSessionService() {
     }
 
     override fun onUpdateNotification(session: MediaSession, startInForegroundRequired: Boolean) {
+        Log.d(TAG, "onUpdateNotification: startInForegroundRequired=$startInForegroundRequired isPlaying=${session.player.isPlaying} playWhenReady=${session.player.playWhenReady} isPlayingAd=${session.player.isPlayingAd}")
         createSessionNotification(session)
     }
 
     override fun onTaskRemoved(rootIntent: Intent?) {
+        Log.d(TAG, "onTaskRemoved called")
         cleanup()
         stopSelf()
     }


### PR DESCRIPTION
…nuncio en Android

Al volver al foreground con un anuncio activo, la TextureView había destruido su surface en background, dejando al ImaAdsLoader sin contexto de renderizado.

Se añade el flag isAdCurrentlyActive (sincronizado con eventos IMA SDK) y se gestiona en onHostResume:
- Player en STATE_READY: reconectar ImaAdsLoader con setPlayer(null/player)
- Player en STATE_IDLE: reinicializar completamente con releasePlayer + initializePlayer

Se añaden también logs diagnósticos en VideoPlaybackService para onUpdateNotification y onTaskRemoved.

Refs: CCMA-2340

<!--
Thanks for opening a PR!
Since this is a volunteer project and is very active, anything you can do to reduce the amount of time needed to review and merge your PR is appreciated.
The following steps will help get your PR merged quickly:

- Update the documentation
If you've added new functionality, update the README.md with an entry for your prop or event.
The entry should be inserted in alphabetical order.

- Provide an example of how to test the change
If the PR requires special testing setup provide all the relevant instructions and files. This may include a sample video file or URL, configuration, or setup steps.

- Focus the PR on only one area
If you're touching multiple different areas that aren't related, break the changes up into multiple PRs.

- Describe the changes
Add a note describing what your PR does. If there is a change to the behavior of the code, explain why it needs to be updated.
-->
## Summary

### Motivation

### Changes

## Test plan