### PR TITLE
feat(PLAYER-175): kill-switch for legacy Youbora chain

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,26 @@ var styles = StyleSheet.create({
 });
 ```
 
+## Overon fork — legacy Youbora kill-switch
+
+This fork carries an inlined NPAW / Youbora analytics chain wired to the `youbora` prop on `<Video>`. While the dedicated [`@overon/react-native-overon-player-analytics-plugins-youbora`](https://gitlab.overon.es/ott/modules/player/react-native-overon-player-analytics-plugins-youbora) module (PLAYER-170) is being validated side-by-side, the legacy chain can be disabled per build via a single flag:
+
+| Platform | How to set |
+|----------|------------|
+| iOS | Add to your app's `Info.plist`: `<key>OVERON_DISABLE_LEGACY_YOUBORA</key><true/>` |
+| Android | Add inside `<application>` in your app's `AndroidManifest.xml`: `<meta-data android:name="OVERON_DISABLE_LEGACY_YOUBORA" android:value="true" />` |
+
+Default: **false** (legacy enabled). Existing apps are unaffected.
+
+When the flag resolves to true:
+
+- `NpawPluginProvider.initialize` is skipped on both platforms
+- No `videoAdapter` is built, no `fireInit` / `fireStart` fires
+- The `youbora` JS prop is silently ignored
+- Cleanup paths remain idempotent (no crash if disposed)
+
+Tracked as **PLAYER-175** (kill-switch) and **PLAYER-171** (full removal once the new plugin is validated).
+
 ## Community support
 We have an discord server where you can ask questions and get help. [Join the discord server](https://discord.gg/WXuM4Tgb9X)
 

--- a/android/src/main/java/com/brentvatne/exoplayer/ReactExoplayerView.java
+++ b/android/src/main/java/com/brentvatne/exoplayer/ReactExoplayerView.java
@@ -1193,7 +1193,13 @@ public class ReactExoplayerView extends FrameLayout implements
          *
          */
 
-        npawPlugin = NpawPluginProvider.getInstance();
+        if (isLegacyYouboraDisabled()) {
+            // PLAYER-175: short-circuit even if another module initialized
+            // NpawPluginProvider — legacy chain is fully off.
+            npawPlugin = null;
+        } else {
+            npawPlugin = NpawPluginProvider.getInstance();
+        }
 
         if (npawPlugin != null) {
             videoAdapter = npawPlugin.videoBuilder()
@@ -2907,7 +2913,33 @@ public class ReactExoplayerView extends FrameLayout implements
      *
      */
 
+    // Legacy Youbora kill-switch (PLAYER-175)
+    //
+    // Set <meta-data android:name="OVERON_DISABLE_LEGACY_YOUBORA" android:value="true" />
+    // inside the consumer app's AndroidManifest.xml to bypass the legacy NPAW
+    // wiring inside this view. When the flag is true, setYoubora() is a no-op
+    // and no videoAdapter is built in setMediaSource. Default false (legacy
+    // enabled) for backwards compatibility. Removed entirely in PLAYER-171.
+    private boolean isLegacyYouboraDisabled() {
+        try {
+            android.content.pm.ApplicationInfo ai = this.themedReactContext
+                    .getPackageManager()
+                    .getApplicationInfo(
+                            this.themedReactContext.getPackageName(),
+                            android.content.pm.PackageManager.GET_META_DATA);
+            return ai.metaData != null
+                    && ai.metaData.getBoolean("OVERON_DISABLE_LEGACY_YOUBORA", false);
+        } catch (Exception e) {
+            return false;
+        }
+    }
+
     public void setYoubora(String accountCode, AnalyticsOptions youboraOptions) {
+
+        if (isLegacyYouboraDisabled()) {
+            android.util.Log.i("Youbora", "Legacy NPAW chain disabled via AndroidManifest meta-data OVERON_DISABLE_LEGACY_YOUBORA (PLAYER-175)");
+            return;
+        }
 
         if (youboraOptions != null) {
 

--- a/ios/Video/RCTVideo.swift
+++ b/ios/Video/RCTVideo.swift
@@ -9,6 +9,17 @@ import Foundation
 import NpawPlugin
 import React
 
+// MARK: - Legacy Youbora kill-switch (PLAYER-175)
+//
+// Set OVERON_DISABLE_LEGACY_YOUBORA = YES in the consumer app's Info.plist to
+// bypass the legacy NPAW / Youbora wiring inside this Video component. When the
+// flag is true, no `NpawPluginProvider.initialize` or `videoBuilder()` runs and
+// the `youbora` JS prop is silently ignored. Default is false (legacy enabled)
+// so existing apps are unaffected. Removed entirely in PLAYER-171.
+private func isLegacyYouboraDisabled() -> Bool {
+    return (Bundle.main.object(forInfoDictionaryKey: "OVERON_DISABLE_LEGACY_YOUBORA") as? Bool) ?? false
+}
+
 // MARK: - RCTVideo
 
 class RCTVideo: UIView, RCTVideoPlayerViewControllerDelegate, RCTPlayerObserverHandler {
@@ -283,10 +294,12 @@ class RCTVideo: UIView, RCTVideoPlayerViewControllerDelegate, RCTPlayerObserverH
         #endif
 
         // Dani Youbora
-        guard let npawPlugin = NpawPluginProvider.shared else { return }
-        
-        npawPlugin.removeAdapter(adapter: self._videoAdapter!)
-        NpawPluginProvider.destroy()
+        if let npawPlugin = NpawPluginProvider.shared {
+            if let adapter = self._videoAdapter {
+                npawPlugin.removeAdapter(adapter: adapter)
+            }
+            NpawPluginProvider.destroy()
+        }
     }
 
     // MARK: - App lifecycle handlers
@@ -606,8 +619,10 @@ class RCTVideo: UIView, RCTVideoPlayerViewControllerDelegate, RCTPlayerObserverH
           DANI: Youbora
          */
 
-        if (self._youbora?.accountCode != nil) {
-        
+        if isLegacyYouboraDisabled() {
+            NSLog("[Youbora] Legacy NPAW chain disabled via Info.plist OVERON_DISABLE_LEGACY_YOUBORA (PLAYER-175)")
+        } else if (self._youbora?.accountCode != nil) {
+
             let analyticsOptions = AnalyticsOptions()
             
             analyticsOptions.contentTransactionCode = self._youbora?.contentTransactionCode
@@ -1675,10 +1690,12 @@ class RCTVideo: UIView, RCTVideoPlayerViewControllerDelegate, RCTPlayerObserverH
         super.removeFromSuperview()
 
         // Dani Youbora
-        guard let npawPlugin = NpawPluginProvider.shared else { return }
-        
-        npawPlugin.removeAdapter(adapter: self._videoAdapter!)
-        NpawPluginProvider.destroy()
+        if let npawPlugin = NpawPluginProvider.shared {
+            if let adapter = self._videoAdapter {
+                npawPlugin.removeAdapter(adapter: adapter)
+            }
+            NpawPluginProvider.destroy()
+        }
     }
 
     // MARK: - Export


### PR DESCRIPTION
## Summary

Adds a build-time flag `OVERON_DISABLE_LEGACY_YOUBORA` that bypasses the inlined NPAW / Youbora wiring on iOS + Android, allowing side-by-side validation of the new dedicated [`@overon/react-native-overon-player-analytics-plugins-youbora`](https://gitlab.overon.es/ott/modules/player/react-native-overon-player-analytics-plugins-youbora) module (PLAYER-170 v1.0.0) before fully removing the legacy chain in PLAYER-171.

JIRA: PLAYER-175 (predecessor of PLAYER-171)

## Mechanism

| Platform | Set via |
|----------|---------|
| iOS | `Info.plist`: `<key>OVERON_DISABLE_LEGACY_YOUBORA</key><true/>` |
| Android | `AndroidManifest.xml` `<meta-data android:name="OVERON_DISABLE_LEGACY_YOUBORA" android:value="true" />` inside `<application>` |

Default: **false** (legacy enabled). Backwards compatible.

When true:
- `NpawPluginProvider.initialize` is skipped on both platforms
- No `videoAdapter` is built, no `fireInit` / `fireStart` fires
- The `youbora` JS prop is silently ignored
- Cleanup paths remain idempotent

## Changes

- `ios/Video/RCTVideo.swift`
  - File-level `isLegacyYouboraDisabled()` helper reads the Info.plist key
  - `setSrc` init block gated on the helper before the existing `accountCode != nil` check
  - **Bonus hardening**: cleanup paths now guard `_videoAdapter` with `if let` instead of force-unwrap (prevents crash when another module initialized NpawPluginProvider but our adapter was never built — exact shape that the kill-switch creates with a third-party NPAW client present)
- `android/src/main/java/com/brentvatne/exoplayer/ReactExoplayerView.java`
  - `isLegacyYouboraDisabled()` helper reads `ApplicationInfo.metaData`
  - `setYoubora()` early-returns when disabled
  - `setMediaSource()` defensive: forces `npawPlugin = null` when disabled, so even if another module touched `NpawPluginProvider.getInstance()` no `videoAdapter` is built
- `README.md` — new "Overon fork — legacy Youbora kill-switch" section

## Test plan

- [x] iOS: builds with no diagnostics introduced by this change (only pre-existing SourceKit "No such module 'NpawPlugin'" without Pods installed)
- [x] Android: Java changes compile (only meta-data lookup uses framework API)
- [ ] Manual smoke iOS — flag false → legacy fires as today
- [ ] Manual smoke iOS — flag true → no NPAW events from this module
- [ ] Manual smoke Android — flag false → legacy fires as today
- [ ] Manual smoke Android — flag true → no NPAW events from this module
- [ ] Validate new plugin (PLAYER-170) runs cleanly with flag true → no duplicate events on NPAW dashboard

## Follow-up

PLAYER-171 — full removal once the new plugin is validated in side-by-side.

🤖 Generated with [Claude Code](https://claude.com/claude-code)