### PR TITLE
feat(analytics)!: migrate player to AnalyticsPluginV2 on() dispatch (PLAYER-209)

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
 		"@jamesacarr/eslint-formatter-github-actions": "^0.2.0",
 		"@overon/react-native-logger": "^0.1.6",
 		"@overon/react-native-overon-errors": "^0.3.2",
-		"@overon/react-native-overon-player-analytics-plugins": "^0.3.0",
+		"@overon/react-native-overon-player-analytics-plugins": "^1.0.0",
 		"@react-native/eslint-config": "^0.72.2",
 		"@release-it/conventional-changelog": "^7.0.2",
 		"@types/jest": "^28.1.2",
@@ -59,7 +59,7 @@
 	"peerDependencies": {
 		"@overon/react-native-logger": "^0.1.6",
 		"@overon/react-native-overon-errors": "^0.1.1",
-		"@overon/react-native-overon-player-analytics-plugins": "^0.3.0",
+		"@overon/react-native-overon-player-analytics-plugins": "^1.0.0",
 		"@react-native-async-storage/async-storage": "*",
 		"@react-native-community/netinfo": "^11.2.1 || ^12.0.0",
 		"@react-native-community/slider": "^4.5.2",

--- a/src/player/core/events/VideoEventsAdapter.ts
+++ b/src/player/core/events/VideoEventsAdapter.ts
@@ -81,10 +81,10 @@ export class VideoEventsAdapter {
 
 	onLoadStart = (data: OnLoadStartData) => {
 		if (!this.isSessionActive) {
-			this.analyticsEvents.onCreatePlaybackSession();
+			this.analyticsEvents.on("onCreatePlaybackSession", undefined);
 			this.isSessionActive = true;
 		}
-		this.analyticsEvents.onSourceChange();
+		this.analyticsEvents.on("onSourceChange", undefined);
 	};
 
 	onLoad = (data: OnLoadData) => {
@@ -94,7 +94,7 @@ export class VideoEventsAdapter {
 		this.metadataHandler.handleLoad(data);
 		this.trackHandler.handleTracksLoad(data);
 
-		this.analyticsEvents.onDurationChange({
+		this.analyticsEvents.on("onDurationChange", {
 			duration: this.duration,
 			previousDuration: 0,
 		});
@@ -138,7 +138,7 @@ export class VideoEventsAdapter {
 	};
 
 	onPlaybackRateChange = (data: OnPlaybackRateChangeData) => {
-		this.analyticsEvents.onPlaybackRateChange({
+		this.analyticsEvents.on("onPlaybackRateChange", {
 			rate: data.playbackRate,
 			previousRate: this.currentPlaybackRate,
 		});
@@ -152,7 +152,7 @@ export class VideoEventsAdapter {
 	};
 
 	onEnd = () => {
-		this.analyticsEvents.onEnd();
+		this.analyticsEvents.on("onEnd", undefined);
 		this.isPlaying = false;
 		this.isSessionActive = false;
 	};
@@ -195,7 +195,7 @@ export class VideoEventsAdapter {
 
 	onReadyForDisplay = () => {
 		// El contenido está listo para mostrar
-		this.analyticsEvents.onBufferStop();
+		this.analyticsEvents.on("onBufferStop", undefined);
 	};
 
 	/*
@@ -204,19 +204,19 @@ export class VideoEventsAdapter {
 	 */
 
 	onApplicationForeground = () => {
-		this.analyticsEvents.onApplicationForeground();
+		this.analyticsEvents.on("onApplicationForeground", undefined);
 	};
 
 	onApplicationBackground = () => {
-		this.analyticsEvents.onApplicationBackground();
+		this.analyticsEvents.on("onApplicationBackground", undefined);
 	};
 
 	onApplicationActive = () => {
-		this.analyticsEvents.onApplicationActive();
+		this.analyticsEvents.on("onApplicationActive", undefined);
 	};
 
 	onApplicationInactive = () => {
-		this.analyticsEvents.onApplicationInactive();
+		this.analyticsEvents.on("onApplicationInactive", undefined);
 	};
 
 	/*

--- a/src/player/core/events/handlers/AdEventsHandler.ts
+++ b/src/player/core/events/handlers/AdEventsHandler.ts
@@ -133,7 +133,7 @@ export class AdEventsHandler {
 		this.currentAdDurationMs = this.extractAdDuration(data);
 		this.currentAdType = this.extractAdType(data);
 
-		this.analyticsEvents.onAdBegin({
+		this.analyticsEvents.on("onAdBegin", {
 			adId: this.currentAdId,
 			adDuration: this.currentAdDurationMs,
 			adPosition: this.extractAdPosition(data),
@@ -142,7 +142,7 @@ export class AdEventsHandler {
 	};
 
 	private handleAdCompleted = () => {
-		this.analyticsEvents.onAdEnd({
+		this.analyticsEvents.on("onAdEnd", {
 			adId: this.currentAdId,
 			completed: true,
 		});
@@ -153,12 +153,12 @@ export class AdEventsHandler {
 	private handleAdSkipped = () => {
 		const skipPosition = this.adStartTime ? Date.now() - this.adStartTime : undefined;
 
-		this.analyticsEvents.onAdSkip({
+		this.analyticsEvents.on("onAdSkip", {
 			adId: this.currentAdId,
 			skipPosition,
 		});
 
-		this.analyticsEvents.onAdEnd({
+		this.analyticsEvents.on("onAdEnd", {
 			adId: this.currentAdId,
 			completed: false,
 		});
@@ -168,20 +168,20 @@ export class AdEventsHandler {
 
 	private handleAdPaused = () => {
 		this.isAdPaused = true;
-		this.analyticsEvents.onAdPause({
+		this.analyticsEvents.on("onAdPause", {
 			adId: this.currentAdId,
 		});
 	};
 
 	private handleAdResumed = () => {
 		this.isAdPaused = false;
-		this.analyticsEvents.onAdResume({
+		this.analyticsEvents.on("onAdResume", {
 			adId: this.currentAdId,
 		});
 	};
 
 	private handleAdError = () => {
-		this.analyticsEvents.onAdEnd({
+		this.analyticsEvents.on("onAdEnd", {
 			adId: this.currentAdId,
 			completed: false,
 		});
@@ -202,7 +202,7 @@ export class AdEventsHandler {
 	private handleAdBreakStarted = (data: OnReceiveAdEventData) => {
 		this.currentAdBreakId = this.extractAdBreakId(data);
 
-		this.analyticsEvents.onAdBreakBegin({
+		this.analyticsEvents.on("onAdBreakBegin", {
 			adBreakId: this.currentAdBreakId,
 			adCount: this.extractAdCount(data),
 			adBreakPosition: this.extractAdBreakPosition(data),
@@ -210,7 +210,7 @@ export class AdEventsHandler {
 	};
 
 	private handleAdBreakEnded = () => {
-		this.analyticsEvents.onAdBreakEnd({
+		this.analyticsEvents.on("onAdBreakEnd", {
 			adBreakId: this.currentAdBreakId,
 		});
 
@@ -223,7 +223,7 @@ export class AdEventsHandler {
 
 	private handleAllAdsCompleted = () => {
 		if (this.currentAdBreakId) {
-			this.analyticsEvents.onAdBreakEnd({
+			this.analyticsEvents.on("onAdBreakEnd", {
 				adBreakId: this.currentAdBreakId,
 			});
 		}
@@ -233,7 +233,7 @@ export class AdEventsHandler {
 	};
 
 	private handleContentResumeRequested = () => {
-		this.analyticsEvents.onContentResume();
+		this.analyticsEvents.on("onContentResume", undefined);
 	};
 
 	private handleAdProgress = (data: OnReceiveAdEventData) => {
@@ -268,7 +268,7 @@ export class AdEventsHandler {
 		const percentageWatched =
 			durationMs > 0 ? Math.min(100, (positionMs / durationMs) * 100) : 0;
 
-		this.analyticsEvents.onAdProgress({
+		this.analyticsEvents.on("onAdProgress", {
 			adId: this.currentAdId,
 			adBreakId: this.currentAdBreakId,
 			adType: this.currentAdType,

--- a/src/player/core/events/handlers/ErrorEventsHandler.ts
+++ b/src/player/core/events/handlers/ErrorEventsHandler.ts
@@ -21,7 +21,7 @@ export class ErrorEventsHandler {
 
 			switch (errorType) {
 				case "network":
-					this.analyticsEvents.onNetworkError({
+					this.analyticsEvents.on("onNetworkError", {
 						errorCode: data.error.code,
 						errorMessage: data.error.localizedDescription,
 						errorType: "network",
@@ -32,7 +32,7 @@ export class ErrorEventsHandler {
 					break;
 
 				case "drm":
-					this.analyticsEvents.onContentProtectionError({
+					this.analyticsEvents.on("onContentProtectionError", {
 						errorCode: data.error.code,
 						errorMessage: data.error.localizedDescription,
 						errorType: "drm",
@@ -42,7 +42,7 @@ export class ErrorEventsHandler {
 					break;
 
 				case "stream":
-					this.analyticsEvents.onStreamError({
+					this.analyticsEvents.on("onStreamError", {
 						errorCode: data.error.code,
 						errorMessage: data.error.localizedDescription,
 						errorType: "playback",
@@ -53,7 +53,7 @@ export class ErrorEventsHandler {
 					break;
 
 				default:
-					this.analyticsEvents.onError({
+					this.analyticsEvents.on("onError", {
 						errorCode: data.error.code,
 						errorMessage: data.error.localizedDescription,
 						errorType: "other",

--- a/src/player/core/events/handlers/MetadataEventsHandler.ts
+++ b/src/player/core/events/handlers/MetadataEventsHandler.ts
@@ -26,7 +26,7 @@ export class MetadataEventsHandler {
 			videoTracks: data.videoTracks,
 		};
 
-		this.analyticsEvents.onMetadataLoaded({
+		this.analyticsEvents.on("onMetadataLoaded", {
 			metadata,
 		});
 	};
@@ -35,7 +35,7 @@ export class MetadataEventsHandler {
 		// Manejar metadatos temporales (captions, chapters, etc.)
 		console.log("[MetadataEventsHandler] Timed metadata:", data.metadata);
 
-		this.analyticsEvents.onMetadataUpdate({
+		this.analyticsEvents.on("onMetadataUpdate", {
 			metadata: data.metadata,
 		});
 	};

--- a/src/player/core/events/handlers/PlaybackEventsHandler.ts
+++ b/src/player/core/events/handlers/PlaybackEventsHandler.ts
@@ -50,7 +50,7 @@ export class PlaybackEventsHandler {
 		}
 
 		// Actualizar posición - se dispara con cada evento onProgress del Video
-		this.analyticsEvents.onPositionUpdate({
+		this.analyticsEvents.on("onPositionUpdate", {
 			position: positionMs,
 			duration: durationMs,
 			bufferedPosition: data.seekableDuration * 1000,
@@ -59,7 +59,7 @@ export class PlaybackEventsHandler {
 		// Disparar evento de progreso - ya viene con la frecuencia correcta del reproductor
 		const percentageWatched = durationMs > 0 ? (positionMs / durationMs) * 100 : 0;
 
-		this.analyticsEvents.onProgress({
+		this.analyticsEvents.on("onProgress", {
 			position: positionMs,
 			duration: durationMs,
 			percentageWatched,
@@ -68,17 +68,17 @@ export class PlaybackEventsHandler {
 
 	handlePlaybackStateChange = (data: OnPlaybackStateChangedData, wasPlaying: boolean) => {
 		if (data.isPlaying && !wasPlaying) {
-			this.analyticsEvents.onPlay();
+			this.analyticsEvents.on("onPlay", undefined);
 		} else if (!data.isPlaying && wasPlaying) {
-			this.analyticsEvents.onPause();
+			this.analyticsEvents.on("onPause", undefined);
 		}
 	};
 
 	handleBuffer = (data: OnBufferData, wasBuffering: boolean) => {
 		if (data.isBuffering && !wasBuffering) {
-			this.analyticsEvents.onBufferStart();
+			this.analyticsEvents.on("onBufferStart", undefined);
 		} else if (!data.isBuffering && wasBuffering) {
-			this.analyticsEvents.onBufferStop();
+			this.analyticsEvents.on("onBufferStop", undefined);
 
 			// Si había un seek en progreso y ya no está buffeando,
 			// es posible que el seek haya terminado
@@ -97,7 +97,7 @@ export class PlaybackEventsHandler {
 
 			// Iniciar el seek
 			if (!this.isSeekInProgress) {
-				this.analyticsEvents.onSeekStart();
+				this.analyticsEvents.on("onSeekStart", undefined);
 				this.isSeekInProgress = true;
 				this.seekFromPosition = fromPositionMs;
 				this.seekToPosition = toPositionMs;
@@ -116,12 +116,12 @@ export class PlaybackEventsHandler {
 	private finishSeek = (currentPositionMs: number) => {
 		try {
 			if (this.isSeekInProgress) {
-				this.analyticsEvents.onSeekEnd({
+				this.analyticsEvents.on("onSeekEnd", {
 					position: currentPositionMs,
 					fromPosition: this.seekFromPosition,
 				});
 
-				this.analyticsEvents.onPositionChange({
+				this.analyticsEvents.on("onPositionChange", {
 					position: currentPositionMs,
 					playbackRate: 1.0, // Esto debería venir del estado del reproductor
 				});
@@ -139,7 +139,7 @@ export class PlaybackEventsHandler {
 	};
 
 	stop = (reason: "user" | "error" | "completion" | "navigation" = "user") => {
-		this.analyticsEvents.onStop({ reason });
+		this.analyticsEvents.on("onStop", { reason });
 	};
 
 	// Método para forzar el final del seek si es necesario

--- a/src/player/core/events/handlers/QualityEventsHandler.ts
+++ b/src/player/core/events/handlers/QualityEventsHandler.ts
@@ -3,7 +3,10 @@
  *
  */
 
-import { PlayerAnalyticsEvents } from "@overon/react-native-overon-player-analytics-plugins";
+import {
+	PlayerAnalyticsEvents,
+	type AnalyticsEventMap,
+} from "@overon/react-native-overon-player-analytics-plugins";
 
 import type {
 	OnBandwidthUpdateData,
@@ -68,7 +71,7 @@ export class QualityEventsHandler {
 
 			// Disparar evento de cambio de calidad
 			if (newQuality !== this.currentQuality) {
-				this.analyticsEvents.onQualityChange({
+				this.analyticsEvents.on("onQualityChange", {
 					quality: newQuality,
 					height: newHeight,
 					width: newWidth,
@@ -79,7 +82,7 @@ export class QualityEventsHandler {
 
 			// Disparar evento de cambio de bitrate
 			if (newBitrate !== this.currentBitrate) {
-				this.analyticsEvents.onBitrateChange({
+				this.analyticsEvents.on("onBitrateChange", {
 					bitrate: newBitrate,
 					previousBitrate: this.currentBitrate,
 					adaptive: true,
@@ -89,7 +92,7 @@ export class QualityEventsHandler {
 
 			// Disparar evento de cambio de resolución
 			if (newWidth !== this.currentWidth || newHeight !== this.currentHeight) {
-				this.analyticsEvents.onResolutionChange({
+				this.analyticsEvents.on("onResolutionChange", {
 					width: newWidth,
 					height: newHeight,
 					previousWidth: this.currentWidth,
@@ -182,7 +185,7 @@ export class QualityEventsHandler {
 
 		// onResolutionChange cuando width/height presentes y cambiaron.
 		if (hasResolution && (width !== this.currentWidth || height !== this.currentHeight)) {
-			this.analyticsEvents.onResolutionChange({
+			this.analyticsEvents.on("onResolutionChange", {
 				width,
 				height,
 				previousWidth: this.currentWidth,
@@ -207,9 +210,7 @@ export class QualityEventsHandler {
 	 * pump, así que casteamos en este único punto para preservar la telemetría.
 	 */
 	private emitQualityChange = (payload: QualityChangePayload) => {
-		this.analyticsEvents.onQualityChange(
-			payload as Parameters<PlayerAnalyticsEvents["onQualityChange"]>[0]
-		);
+		this.analyticsEvents.on("onQualityChange", payload as AnalyticsEventMap["onQualityChange"]);
 	};
 
 	private getQualityLabel = (width?: number, height?: number): string => {

--- a/src/player/core/events/handlers/TrackEventsHandler.ts
+++ b/src/player/core/events/handlers/TrackEventsHandler.ts
@@ -25,7 +25,7 @@ export class TrackEventsHandler {
 		const selectedAudio = data.audioTracks.find(track => track.selected);
 		if (selectedAudio) {
 			this.currentAudioIndex = selectedAudio.index;
-			this.analyticsEvents.onAudioTrackChange({
+			this.analyticsEvents.on("onAudioTrackChange", {
 				trackIndex: selectedAudio.index,
 				trackLabel: selectedAudio.title,
 				language: selectedAudio.language,
@@ -36,7 +36,7 @@ export class TrackEventsHandler {
 		const selectedText = data.textTracks.find(track => track.selected);
 		if (selectedText) {
 			this.currentTextIndex = selectedText.index;
-			this.analyticsEvents.onSubtitleTrackChange({
+			this.analyticsEvents.on("onSubtitleTrackChange", {
 				trackIndex: selectedText.index,
 				trackLabel: selectedText.title,
 				language: selectedText.language,
@@ -49,7 +49,7 @@ export class TrackEventsHandler {
 
 		if (selectedTrack && selectedTrack.index !== this.currentAudioIndex) {
 			this.currentAudioIndex = selectedTrack.index;
-			this.analyticsEvents.onAudioTrackChange({
+			this.analyticsEvents.on("onAudioTrackChange", {
 				trackIndex: selectedTrack.index,
 				trackLabel: selectedTrack.title,
 				language: selectedTrack.language,
@@ -62,26 +62,26 @@ export class TrackEventsHandler {
 
 		if (selectedTrack && selectedTrack.index !== this.currentTextIndex) {
 			this.currentTextIndex = selectedTrack.index;
-			this.analyticsEvents.onSubtitleTrackChange({
+			this.analyticsEvents.on("onSubtitleTrackChange", {
 				trackIndex: selectedTrack.index,
 				trackLabel: selectedTrack.title,
 				language: selectedTrack.language,
 			});
 
-			this.analyticsEvents.onSubtitleShow({
+			this.analyticsEvents.on("onSubtitleShow", {
 				trackIndex: selectedTrack.index,
 			});
 		} else if (!selectedTrack && this.currentTextIndex !== -1) {
 			// Los subtítulos se han desactivado
 			this.currentTextIndex = -1;
-			this.analyticsEvents.onSubtitleHide();
+			this.analyticsEvents.on("onSubtitleHide", undefined);
 		}
 	};
 
 	handleVolumeChange = (data: OnVolumeChangeData, previousVolume: number, wasMuted: boolean) => {
 		// Detectar cambios en el volumen
 		if (data.volume !== previousVolume) {
-			this.analyticsEvents.onVolumeChange({
+			this.analyticsEvents.on("onVolumeChange", {
 				volume: data.volume,
 				previousVolume: previousVolume,
 			});
@@ -91,7 +91,7 @@ export class TrackEventsHandler {
 		// Detectar cambios en el estado de silencio
 		const isMuted = data.volume === 0;
 		if (isMuted !== wasMuted) {
-			this.analyticsEvents.onMuteChange({
+			this.analyticsEvents.on("onMuteChange", {
 				muted: isMuted,
 			});
 			this.currentMuted = isMuted;

--- a/src/player/core/events/handlers/__tests__/AdEventsHandler.test.ts
+++ b/src/player/core/events/handlers/__tests__/AdEventsHandler.test.ts
@@ -10,22 +10,22 @@ jest.mock(
 
 function buildAnalyticsEventsSpy() {
 	return {
-		onAdBegin: jest.fn(),
-		onAdEnd: jest.fn(),
-		onAdPause: jest.fn(),
-		onAdResume: jest.fn(),
-		onAdSkip: jest.fn(),
-		onAdProgress: jest.fn(),
-		onAdBreakBegin: jest.fn(),
-		onAdBreakEnd: jest.fn(),
-		onContentResume: jest.fn(),
+		on: jest.fn(),
 	};
 }
 
-const buildEvent = (
-	event: string,
-	data?: Record<string, unknown>
-): OnReceiveAdEventData =>
+// Helper: devuelve los payloads de las llamadas a `on(event, payload)` cuya
+// clave de evento coincide, en orden de emisión.
+function payloadsFor(
+	spy: ReturnType<typeof buildAnalyticsEventsSpy>,
+	event: string
+): Array<Record<string, unknown>> {
+	return spy.on.mock.calls
+		.filter(call => call[0] === event)
+		.map(call => call[1] as Record<string, unknown>);
+}
+
+const buildEvent = (event: string, data?: Record<string, unknown>): OnReceiveAdEventData =>
 	({
 		event,
 		data,
@@ -53,16 +53,16 @@ describe("AdEventsHandler", () => {
 					position: 0,
 				})
 			);
-			analyticsEvents.onAdBegin.mockClear();
+			analyticsEvents.on.mockClear();
 		});
 
 		it("emite onAdProgress con shape iOS (currentTime/duration en segundos)", () => {
-			handler.handleAdEvent(
-				buildEvent("AD_PROGRESS", { currentTime: 3.5, duration: 15 })
-			);
+			handler.handleAdEvent(buildEvent("AD_PROGRESS", { currentTime: 3.5, duration: 15 }));
 
-			expect(analyticsEvents.onAdProgress).toHaveBeenCalledTimes(1);
-			expect(analyticsEvents.onAdProgress).toHaveBeenCalledWith(
+			const progressCalls = payloadsFor(analyticsEvents, "onAdProgress");
+			expect(progressCalls).toHaveLength(1);
+			expect(analyticsEvents.on).toHaveBeenCalledWith(
+				"onAdProgress",
 				expect.objectContaining({
 					adId: "ad-1",
 					adBreakId: "break-1",
@@ -70,7 +70,7 @@ describe("AdEventsHandler", () => {
 					duration: 15000,
 				})
 			);
-			expect(analyticsEvents.onAdProgress.mock.calls[0][0].percentageWatched).toBeCloseTo(
+			expect(progressCalls[0]!.percentageWatched as number).toBeCloseTo(
 				(3500 / 15000) * 100,
 				2
 			);
@@ -81,8 +81,9 @@ describe("AdEventsHandler", () => {
 				buildEvent("AD_PROGRESS", { position: "7000", duration: "15000" })
 			);
 
-			expect(analyticsEvents.onAdProgress).toHaveBeenCalledTimes(1);
-			expect(analyticsEvents.onAdProgress).toHaveBeenCalledWith(
+			expect(payloadsFor(analyticsEvents, "onAdProgress")).toHaveLength(1);
+			expect(analyticsEvents.on).toHaveBeenCalledWith(
+				"onAdProgress",
 				expect.objectContaining({ position: 7000, duration: 15000 })
 			);
 		});
@@ -97,12 +98,12 @@ describe("AdEventsHandler", () => {
 			now += 100;
 			handler.handleAdEvent(buildEvent("AD_PROGRESS", { currentTime: 1.2, duration: 15 }));
 
-			expect(analyticsEvents.onAdProgress).toHaveBeenCalledTimes(1);
+			expect(payloadsFor(analyticsEvents, "onAdProgress")).toHaveLength(1);
 
 			now += 100; // total 300ms desde la 1ª emisión
 			handler.handleAdEvent(buildEvent("AD_PROGRESS", { currentTime: 1.3, duration: 15 }));
 
-			expect(analyticsEvents.onAdProgress).toHaveBeenCalledTimes(2);
+			expect(payloadsFor(analyticsEvents, "onAdProgress")).toHaveLength(2);
 
 			(Date.now as jest.Mock).mockRestore();
 		});
@@ -112,7 +113,7 @@ describe("AdEventsHandler", () => {
 			jest.spyOn(Date, "now").mockImplementation(() => now);
 
 			handler.handleAdEvent(buildEvent("AD_PROGRESS", { currentTime: 1, duration: 15 }));
-			expect(analyticsEvents.onAdProgress).toHaveBeenCalledTimes(1);
+			expect(payloadsFor(analyticsEvents, "onAdProgress")).toHaveLength(1);
 
 			handler.handleAdEvent(buildEvent("PAUSED"));
 
@@ -121,13 +122,13 @@ describe("AdEventsHandler", () => {
 			now += 1000;
 			handler.handleAdEvent(buildEvent("AD_PROGRESS", { currentTime: 1, duration: 15 }));
 
-			expect(analyticsEvents.onAdProgress).toHaveBeenCalledTimes(1); // sigue en 1
+			expect(payloadsFor(analyticsEvents, "onAdProgress")).toHaveLength(1); // sigue en 1
 
 			handler.handleAdEvent(buildEvent("RESUMED"));
 			now += 1000;
 			handler.handleAdEvent(buildEvent("AD_PROGRESS", { currentTime: 5, duration: 15 }));
 
-			expect(analyticsEvents.onAdProgress).toHaveBeenCalledTimes(2);
+			expect(payloadsFor(analyticsEvents, "onAdProgress")).toHaveLength(2);
 
 			(Date.now as jest.Mock).mockRestore();
 		});
@@ -138,7 +139,8 @@ describe("AdEventsHandler", () => {
 
 			handler.handleAdEvent(buildEvent("AD_PROGRESS", { currentTime: 5 }));
 
-			expect(analyticsEvents.onAdProgress).toHaveBeenCalledWith(
+			expect(analyticsEvents.on).toHaveBeenCalledWith(
+				"onAdProgress",
 				expect.objectContaining({ position: 5000, duration: 15000 })
 			);
 
@@ -150,7 +152,7 @@ describe("AdEventsHandler", () => {
 			handler.handleAdEvent(buildEvent("MIDPOINT"));
 			handler.handleAdEvent(buildEvent("THIRD_QUARTILE"));
 
-			expect(analyticsEvents.onAdProgress).not.toHaveBeenCalled();
+			expect(analyticsEvents.on).not.toHaveBeenCalledWith("onAdProgress", expect.anything());
 		});
 	});
 
@@ -203,10 +205,10 @@ describe("AdEventsHandler", () => {
 			handler.handleAdEvent(buildEvent("COMPLETED"));
 			handler.handleAdEvent(buildEvent("AD_BREAK_ENDED"));
 
-			expect(analyticsEvents.onAdBreakBegin).toHaveBeenCalledTimes(1);
-			expect(analyticsEvents.onAdBegin).toHaveBeenCalledTimes(1);
-			expect(analyticsEvents.onAdEnd).toHaveBeenCalledTimes(1);
-			expect(analyticsEvents.onAdBreakEnd).toHaveBeenCalledTimes(1);
+			expect(payloadsFor(analyticsEvents, "onAdBreakBegin")).toHaveLength(1);
+			expect(payloadsFor(analyticsEvents, "onAdBegin")).toHaveLength(1);
+			expect(payloadsFor(analyticsEvents, "onAdEnd")).toHaveLength(1);
+			expect(payloadsFor(analyticsEvents, "onAdBreakEnd")).toHaveLength(1);
 		});
 	});
 });

--- a/src/player/core/events/handlers/__tests__/PlaybackEventsHandler.test.ts
+++ b/src/player/core/events/handlers/__tests__/PlaybackEventsHandler.test.ts
@@ -12,16 +12,7 @@ jest.mock(
 
 function buildAnalyticsEventsSpy() {
 	return {
-		onPositionUpdate: jest.fn(),
-		onProgress: jest.fn(),
-		onSeekStart: jest.fn(),
-		onSeekEnd: jest.fn(),
-		onPositionChange: jest.fn(),
-		onPlay: jest.fn(),
-		onPause: jest.fn(),
-		onBufferStart: jest.fn(),
-		onBufferStop: jest.fn(),
-		onStop: jest.fn(),
+		on: jest.fn(),
 	};
 }
 
@@ -46,14 +37,12 @@ describe("PlaybackEventsHandler — gate ad/media", () => {
 		it("emite onPositionUpdate y onProgress", () => {
 			handler.handleProgress(buildProgressData(10, 100), 10000, 100000);
 
-			expect(analyticsEvents.onPositionUpdate).toHaveBeenCalledTimes(1);
-			expect(analyticsEvents.onPositionUpdate).toHaveBeenCalledWith({
+			expect(analyticsEvents.on).toHaveBeenCalledWith("onPositionUpdate", {
 				position: 10000,
 				duration: 100000,
 				bufferedPosition: 100 * 1000,
 			});
-			expect(analyticsEvents.onProgress).toHaveBeenCalledTimes(1);
-			expect(analyticsEvents.onProgress).toHaveBeenCalledWith({
+			expect(analyticsEvents.on).toHaveBeenCalledWith("onProgress", {
 				position: 10000,
 				duration: 100000,
 				percentageWatched: 10,
@@ -63,7 +52,8 @@ describe("PlaybackEventsHandler — gate ad/media", () => {
 		it("calcula percentageWatched=0 cuando duration es 0", () => {
 			handler.handleProgress(buildProgressData(5, 0), 5000, 0);
 
-			expect(analyticsEvents.onProgress).toHaveBeenCalledWith(
+			expect(analyticsEvents.on).toHaveBeenCalledWith(
+				"onProgress",
 				expect.objectContaining({ percentageWatched: 0 })
 			);
 		});
@@ -73,8 +63,11 @@ describe("PlaybackEventsHandler — gate ad/media", () => {
 		it("NO emite onPositionUpdate ni onProgress durante un ad", () => {
 			handler.handleProgress(buildProgressData(10, 100), 10000, 100000, true);
 
-			expect(analyticsEvents.onPositionUpdate).not.toHaveBeenCalled();
-			expect(analyticsEvents.onProgress).not.toHaveBeenCalled();
+			expect(analyticsEvents.on).not.toHaveBeenCalledWith(
+				"onPositionUpdate",
+				expect.anything()
+			);
+			expect(analyticsEvents.on).not.toHaveBeenCalledWith("onProgress", expect.anything());
 		});
 
 		it("ticks repetidos durante el break siguen sin emitir", () => {
@@ -82,18 +75,21 @@ describe("PlaybackEventsHandler — gate ad/media", () => {
 			handler.handleProgress(buildProgressData(11, 100), 11000, 100000, true);
 			handler.handleProgress(buildProgressData(12, 100), 12000, 100000, true);
 
-			expect(analyticsEvents.onPositionUpdate).not.toHaveBeenCalled();
-			expect(analyticsEvents.onProgress).not.toHaveBeenCalled();
+			expect(analyticsEvents.on).not.toHaveBeenCalledWith(
+				"onPositionUpdate",
+				expect.anything()
+			);
+			expect(analyticsEvents.on).not.toHaveBeenCalledWith("onProgress", expect.anything());
 		});
 	});
 
 	describe("transición ad → contenido", () => {
 		it("vuelve a emitir cuando isAdActive cambia a false", () => {
 			handler.handleProgress(buildProgressData(10, 100), 10000, 100000, true);
-			expect(analyticsEvents.onProgress).not.toHaveBeenCalled();
+			expect(analyticsEvents.on).not.toHaveBeenCalledWith("onProgress", expect.anything());
 
 			handler.handleProgress(buildProgressData(11, 100), 11000, 100000, false);
-			expect(analyticsEvents.onProgress).toHaveBeenCalledTimes(1);
+			expect(analyticsEvents.on).toHaveBeenCalledWith("onProgress", expect.anything());
 		});
 	});
 });

--- a/src/player/core/events/handlers/__tests__/QualityEventsHandler.test.ts
+++ b/src/player/core/events/handlers/__tests__/QualityEventsHandler.test.ts
@@ -16,10 +16,19 @@ jest.mock(
 
 function buildAnalyticsEventsSpy() {
 	return {
-		onQualityChange: jest.fn(),
-		onBitrateChange: jest.fn(),
-		onResolutionChange: jest.fn(),
+		on: jest.fn(),
 	};
+}
+
+// Helper: devuelve los payloads de las llamadas a `on(event, payload)` cuya
+// clave de evento coincide, en orden de emisión.
+function payloadsFor(
+	spy: ReturnType<typeof buildAnalyticsEventsSpy>,
+	event: string
+): Array<Record<string, unknown>> {
+	return spy.on.mock.calls
+		.filter(call => call[0] === event)
+		.map(call => call[1] as Record<string, unknown>);
 }
 
 describe("QualityEventsHandler — QoE telemetry (PLAYER-200)", () => {
@@ -40,9 +49,18 @@ describe("QualityEventsHandler — QoE telemetry (PLAYER-200)", () => {
 			handler.handleBandwidthUpdate({ bitrate: 3_000_000 } as OnBandwidthUpdateData);
 			handler.handleBandwidthUpdate({ bitrate: -1 } as OnBandwidthUpdateData);
 
-			expect(analyticsEvents.onQualityChange).not.toHaveBeenCalled();
-			expect(analyticsEvents.onBitrateChange).not.toHaveBeenCalled();
-			expect(analyticsEvents.onResolutionChange).not.toHaveBeenCalled();
+			expect(analyticsEvents.on).not.toHaveBeenCalledWith(
+				"onQualityChange",
+				expect.anything()
+			);
+			expect(analyticsEvents.on).not.toHaveBeenCalledWith(
+				"onBitrateChange",
+				expect.anything()
+			);
+			expect(analyticsEvents.on).not.toHaveBeenCalledWith(
+				"onResolutionChange",
+				expect.anything()
+			);
 		});
 	});
 
@@ -58,8 +76,9 @@ describe("QualityEventsHandler — QoE telemetry (PLAYER-200)", () => {
 				height: 1080,
 			} as OnPlaybackMetricsData);
 
-			expect(analyticsEvents.onQualityChange).toHaveBeenCalledTimes(1);
-			const payload = analyticsEvents.onQualityChange.mock.calls[0][0];
+			const qualityCalls = payloadsFor(analyticsEvents, "onQualityChange");
+			expect(qualityCalls).toHaveLength(1);
+			const payload = qualityCalls[0]!;
 			expect(payload).toEqual(
 				expect.objectContaining({
 					quality: "1080p",
@@ -75,8 +94,8 @@ describe("QualityEventsHandler — QoE telemetry (PLAYER-200)", () => {
 			expect(payload.bitrate).toBe(4_200_000);
 			expect(payload.throughput).toBe(220_000_000);
 
-			expect(analyticsEvents.onResolutionChange).toHaveBeenCalledTimes(1);
-			expect(analyticsEvents.onResolutionChange).toHaveBeenCalledWith({
+			expect(payloadsFor(analyticsEvents, "onResolutionChange")).toHaveLength(1);
+			expect(analyticsEvents.on).toHaveBeenCalledWith("onResolutionChange", {
 				width: 1920,
 				height: 1080,
 				previousWidth: 0,
@@ -90,13 +109,17 @@ describe("QualityEventsHandler — QoE telemetry (PLAYER-200)", () => {
 				framesPerSecond: 25,
 			} as OnPlaybackMetricsData);
 
-			expect(analyticsEvents.onQualityChange).toHaveBeenCalledTimes(1);
-			const payload = analyticsEvents.onQualityChange.mock.calls[0][0];
+			const qualityCalls = payloadsFor(analyticsEvents, "onQualityChange");
+			expect(qualityCalls).toHaveLength(1);
+			const payload = qualityCalls[0]!;
 			expect(payload.throughput).toBe(5_000_000);
 			expect(payload.framesPerSecond).toBe(25);
 			expect(payload.quality).toBeUndefined();
 			expect(payload.rendition).toBeUndefined();
-			expect(analyticsEvents.onResolutionChange).not.toHaveBeenCalled();
+			expect(analyticsEvents.on).not.toHaveBeenCalledWith(
+				"onResolutionChange",
+				expect.anything()
+			);
 		});
 
 		it("PLAYER-201: tras una rendición con resolución, un tick métrico sin resolución re-envía la última rendición", () => {
@@ -111,7 +134,8 @@ describe("QualityEventsHandler — QoE telemetry (PLAYER-200)", () => {
 				throughput: 5_000_000,
 			} as OnPlaybackMetricsData);
 
-			const second = analyticsEvents.onQualityChange.mock.calls[1][0];
+			const qualityCalls = payloadsFor(analyticsEvents, "onQualityChange");
+			const second = qualityCalls[1]!;
 			expect(second.rendition).toBe("1080p");
 			expect(second.quality).toBe("1080p");
 			expect(second.throughput).toBe(5_000_000);
@@ -123,7 +147,7 @@ describe("QualityEventsHandler — QoE telemetry (PLAYER-200)", () => {
 				throughput: -1,
 			} as OnPlaybackMetricsData);
 
-			const payload = analyticsEvents.onQualityChange.mock.calls[0][0];
+			const payload = payloadsFor(analyticsEvents, "onQualityChange")[0]!;
 			expect(payload.bitrate).toBe(4_200_000);
 			expect(payload.throughput).toBeUndefined();
 		});
@@ -134,7 +158,8 @@ describe("QualityEventsHandler — QoE telemetry (PLAYER-200)", () => {
 				droppedFrames: 0,
 			} as OnPlaybackMetricsData);
 
-			expect(analyticsEvents.onQualityChange).toHaveBeenCalledWith(
+			expect(analyticsEvents.on).toHaveBeenCalledWith(
+				"onQualityChange",
 				expect.objectContaining({ throughput: 5_000_000, droppedFrames: 0 })
 			);
 		});
@@ -146,8 +171,14 @@ describe("QualityEventsHandler — QoE telemetry (PLAYER-200)", () => {
 				framesPerSecond: 0,
 			} as OnPlaybackMetricsData);
 
-			expect(analyticsEvents.onQualityChange).not.toHaveBeenCalled();
-			expect(analyticsEvents.onResolutionChange).not.toHaveBeenCalled();
+			expect(analyticsEvents.on).not.toHaveBeenCalledWith(
+				"onQualityChange",
+				expect.anything()
+			);
+			expect(analyticsEvents.on).not.toHaveBeenCalledWith(
+				"onResolutionChange",
+				expect.anything()
+			);
 		});
 
 		it("no emite onResolutionChange si la resolución no cambia", () => {
@@ -159,8 +190,8 @@ describe("QualityEventsHandler — QoE telemetry (PLAYER-200)", () => {
 			handler.handlePlaybackMetrics(data);
 			handler.handlePlaybackMetrics(data);
 
-			expect(analyticsEvents.onResolutionChange).toHaveBeenCalledTimes(1);
-			expect(analyticsEvents.onQualityChange).toHaveBeenCalledTimes(2);
+			expect(payloadsFor(analyticsEvents, "onResolutionChange")).toHaveLength(1);
+			expect(payloadsFor(analyticsEvents, "onQualityChange")).toHaveLength(2);
 		});
 	});
 
@@ -172,18 +203,18 @@ describe("QualityEventsHandler — QoE telemetry (PLAYER-200)", () => {
 				],
 			} as OnVideoTracksData);
 
-			expect(analyticsEvents.onQualityChange).toHaveBeenCalledWith({
+			expect(analyticsEvents.on).toHaveBeenCalledWith("onQualityChange", {
 				quality: "1080p",
 				height: 1080,
 				width: 1920,
 				bitrate: 5_000_000,
 			});
-			expect(analyticsEvents.onBitrateChange).toHaveBeenCalledWith({
+			expect(analyticsEvents.on).toHaveBeenCalledWith("onBitrateChange", {
 				bitrate: 5_000_000,
 				previousBitrate: 0,
 				adaptive: true,
 			});
-			expect(analyticsEvents.onResolutionChange).toHaveBeenCalledWith({
+			expect(analyticsEvents.on).toHaveBeenCalledWith("onResolutionChange", {
 				width: 1920,
 				height: 1080,
 				previousWidth: 0,

--- a/src/player/core/events/hooks/useVideoAnalytics.ts
+++ b/src/player/core/events/hooks/useVideoAnalytics.ts
@@ -369,7 +369,7 @@ export const useVideoAnalytics = ({
 		onAudioBecomingNoisy: useCallback(() => {
 			if (analyticsEventsRef.current) {
 				try {
-					analyticsEventsRef.current.onPause();
+					analyticsEventsRef.current.on("onPause", undefined);
 				} catch (error) {
 					onInternalError?.(
 						createHandlerError("AUDIO_BECOMING_NOISY_FAILED", {
@@ -383,7 +383,7 @@ export const useVideoAnalytics = ({
 		onIdle: useCallback(() => {
 			if (analyticsEventsRef.current) {
 				try {
-					analyticsEventsRef.current.onPause();
+					analyticsEventsRef.current.on("onPause", undefined);
 				} catch (error) {
 					onInternalError?.(
 						createHandlerError("IDLE_FAILED", { originalError: error as Error })

--- a/src/player/flavours/audio/index.tsx
+++ b/src/player/flavours/audio/index.tsx
@@ -687,7 +687,7 @@ export function AudioFlavour(props: AudioFlavourProps): React.ReactElement {
 				props.events.onNext();
 
 				// Evento analíticas
-				analyticsEvents.onStop({ reason: "navigation" });
+				analyticsEvents.on("onStop", { reason: "navigation" });
 			}
 
 			if (id === CONTROL_ACTION.PREVIOUS && props.events?.onPrevious) {
@@ -695,7 +695,7 @@ export function AudioFlavour(props: AudioFlavourProps): React.ReactElement {
 				props.events.onPrevious();
 
 				// Evento analíticas
-				analyticsEvents.onStop({ reason: "navigation" });
+				analyticsEvents.on("onStop", { reason: "navigation" });
 			}
 
 			if (id === CONTROL_ACTION.SPEED_RATE && typeof value === "number") {

--- a/src/player/flavours/normal/index.tsx
+++ b/src/player/flavours/normal/index.tsx
@@ -1186,7 +1186,7 @@ export function NormalFlavour(props: NormalFlavourProps): React.ReactElement {
 			props.events?.onNext();
 
 			// Evento analíticas
-			analyticsEvents.onStop({ reason: "navigation" });
+			analyticsEvents.on("onStop", { reason: "navigation" });
 		}
 
 		if (id === CONTROL_ACTION.PREVIOUS && props.events?.onPrevious) {
@@ -1194,7 +1194,7 @@ export function NormalFlavour(props: NormalFlavourProps): React.ReactElement {
 			props.events.onPrevious();
 
 			// Evento analíticas
-			analyticsEvents.onStop({ reason: "navigation" });
+			analyticsEvents.on("onStop", { reason: "navigation" });
 		}
 
 		if (


### PR DESCRIPTION
## PLAYER-209 (consumer) — migrate analytics host to `AnalyticsPluginV2.on()`

The analytics framework's v1.0 cutover (`@overon/react-native-overon-player-analytics-plugins` v1.0.0, PLAYER-209) removed the 43 named `on*` methods on `PlayerAnalyticsEvents` in favour of a single typed dispatch `on<E>(event, payload)`. This migrates the player's analytics integration accordingly.

### Changes
- **`VideoEventsAdapter` + 6 handlers** (Playback/Ad/Track/Quality/Metadata/Error): `analyticsEvents.onX(p)` → `analyticsEvents.on("onX", p)` (void events pass `undefined`).
- **`QualityEventsHandler`**: payload type via `AnalyticsEventMap["onQualityChange"]` instead of the now-removed `Parameters<PlayerAnalyticsEvents["onQualityChange"]>`.
- **`useVideoAnalytics`** + **audio/normal flavours**: `onPause`/`onStop` migrated.
- Handler tests updated to the `on()` contract.
- Bump dep + peerDep `^0.3.0` → `^1.0.0`.

### Not touched (different interfaces)
Player event props (`props.events.*`), cast callbacks, `audioPlayerBar`, and the `VideoEventsAdapter` public facade — unchanged.

### ⚠️ Lockstep
Requires framework **v1.0.0**. Don't merge/release the player ahead of the framework publish — they go together.

### Verification
- `yarn tsc` against framework v1.0.0: **0 new errors** introduced (the ~58 "Property 'onX' does not exist" errors the new types surface are all resolved by this migration; remaining repo tsc errors are pre-existing and unrelated).
- Analytics suites: **3 suites, 24 tests green** (`npx jest src/player/core/events`).

Refs: PLAYER-209, framework MR !6.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
